### PR TITLE
Update Dockerfile to use Homebrew for Aderyn installation

### DIFF
--- a/foundry/mounted/.devcontainer/Dockerfile
+++ b/foundry/mounted/.devcontainer/Dockerfile
@@ -13,6 +13,15 @@ SHELL ["/usr/bin/zsh", "-c"]
 # Dropping privileges
 USER vscode
 
+# Install dependencies for Homebrew
+RUN sudo apt-get install -y curl git build-essential
+
+# Install Homebrew
+RUN /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"
+
+# Add Homebrew to PATH
+ENV PATH="/home/linuxbrew/.linuxbrew/bin:/home/linuxbrew/.linuxbrew/sbin:${PATH}"
+
 # Install rust
 RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y && source $HOME/.cargo/env
 
@@ -33,9 +42,11 @@ RUN uv tool install crytic-compile
 RUN curl -L https://foundry.paradigm.xyz | zsh
 RUN foundryup
 
-# Aderyn
-RUN curl -L https://raw.githubusercontent.com/Cyfrin/aderyn/dev/cyfrinup/install | zsh
-RUN cyfrinup
+# Install Aderyn using Homebrew
+RUN brew install cyfrin/tap/aderyn
+
+# Verify Aderyn installation
+RUN aderyn --version
 
 # Clean up
 RUN sudo apt-get autoremove -y && sudo apt-get clean -y

--- a/foundry/unmounted/.devcontainer/Dockerfile
+++ b/foundry/unmounted/.devcontainer/Dockerfile
@@ -13,6 +13,15 @@ SHELL ["/usr/bin/zsh", "-c"]
 # Dropping privileges
 USER vscode
 
+# Install dependencies for Homebrew
+RUN sudo apt-get install -y curl git build-essential
+
+# Install Homebrew
+RUN /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"
+
+# Add Homebrew to PATH
+ENV PATH="/home/linuxbrew/.linuxbrew/bin:/home/linuxbrew/.linuxbrew/sbin:${PATH}"
+
 # Install rust
 RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y && source $HOME/.cargo/env
 
@@ -33,9 +42,11 @@ RUN uv tool install crytic-compile
 RUN curl -L https://foundry.paradigm.xyz | zsh
 RUN foundryup
 
-# Aderyn
-RUN curl -L https://raw.githubusercontent.com/Cyfrin/aderyn/dev/cyfrinup/install | zsh
-RUN cyfrinup
+# Install Aderyn using Homebrew
+RUN brew install cyfrin/tap/aderyn
+
+# Verify Aderyn installation
+RUN aderyn --version
 
 # Clean up
 RUN sudo apt-get autoremove -y && sudo apt-get clean -y


### PR DESCRIPTION
**Problem:**
The current Dockerfile attempts to install Aderyn using the `cyfrinup` script, but the installation URL (`https://raw.githubusercontent.com/Cyfrin/aderyn/dev/cyfrinup/install`) returns a `404` error. This is because Aderyn has updated its installation process, and the `cyfrinup` script is no longer available at this location.

**Solution:**
This PR updates the Dockerfile to use **Homebrew** for installing Aderyn, as recommended in Aderyn's updated README.md. The changes have been tested and verified to work in my local environment.

**Changes:**
1. Added steps to install Homebrew:
   ```dockerfile
   RUN sudo apt-get install -y curl git build-essential
   RUN /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"
   ENV PATH="/home/linuxbrew/.linuxbrew/bin:/home/linuxbrew/.linuxbrew/sbin:${PATH}"

2. Updated the Dockerfile to install Aderyn using Homebrew:
```dockerfile
RUN brew install cyfrin/tap/aderyn
```

**Testing:**
I've tested the updated Dockerfile, and Aderyn installs successfully. You can verify this by running:
```bash
aderyn --version
```

**Reference:**
Aderyn's updated installation instructions can be found here: [Aderyn README.md](https://github.com/Cyfrin/aderyn#installation).

## Updated Dockerfile (Full):
Here’s the full updated Dockerfile for reference:
```dockerfile
# Base debian build (latest).
FROM mcr.microsoft.com/vscode/devcontainers/base:debian

# Update packages.
RUN apt-get update

# Set the default shell to zsh
ENV SHELL=/usr/bin/zsh

# Running everything under zsh
SHELL ["/usr/bin/zsh", "-c"]

# Dropping privileges
USER vscode

# Install dependencies for Homebrew
RUN sudo apt-get install -y curl git build-essential

# Install Homebrew
RUN /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"

# Add Homebrew to PATH
ENV PATH="/home/linuxbrew/.linuxbrew/bin:/home/linuxbrew/.linuxbrew/sbin:${PATH}"

# Install rust
RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y && source $HOME/.cargo/env

# Install uv and add to PATH
# See https://docs.astral.sh/uv/guides/integration/docker/
COPY --from=ghcr.io/astral-sh/uv:latest /uv /uvx /bin/
ENV PATH="/home/vscode/.local/bin:$PATH"

# Add uv to shell configuration
RUN echo 'export PATH="/home/vscode/.cargo/bin:$PATH"' >> ~/.zshrc

# Install tools using uv
RUN uv tool install solc-select
RUN uv tool install slither-analyzer
RUN uv tool install crytic-compile

# Foundry framework
RUN curl -L https://foundry.paradigm.xyz | zsh
RUN foundryup

# Install Aderyn using Homebrew
RUN brew install cyfrin/tap/aderyn

# Verify Aderyn installation
RUN aderyn --version

# Clean up
RUN sudo apt-get autoremove -y && sudo apt-get clean -y
```