### PR TITLE
Fix: Correct syntax in devcontainer welcome message

### DIFF
--- a/foundry/mounted/.devcontainer/devcontainer.json
+++ b/foundry/mounted/.devcontainer/devcontainer.json
@@ -44,7 +44,7 @@
     // Use 'postCreateCommand' to run commands after the container is created.
     // We're using a gist, but you can also reference the raw install-tool from your repo.
     // Unless you mount the scripts folder as
-    "postCreateCommand": "echo Welcome to Cyfrin's dev-container. If you'd like to build your own, you can check out an article The Red Guild have created for you at their blog under https://blog.theredguild.org/where-do-you-run-your-code;zsh"
+    "postCreateCommand": "echo Welcome to Cyfrin's dev-container. If you'd like to build your own, you can check out an article The Red Guild have created for you at their blog under https://blog.theredguild.org/where-do-you-run-your-code"
     // Uncomment to connect as root instead. More info: https://aka.ms/dev-containers-non-root.
     // "remoteUser": "root"
 }

--- a/foundry/unmounted/.devcontainer/devcontainer.json
+++ b/foundry/unmounted/.devcontainer/devcontainer.json
@@ -21,7 +21,12 @@
                 "NomicFoundation.hardhat-solidity",
                 "tintinweb.solidity-visual-auditor",
                 "trailofbits.weaudit",
-                "tintinweb.solidity-metrics"
+                "tintinweb.solidity-metrics",
+                "eamodio.gitlens",
+                "mhutchie.git-graph",
+                "GitHub.copilot",
+                "GitHub.copilot-chat",
+                "tamasfe.even-better-toml"
             ],
             "settings": {
                 "terminal.integrated.defaultProfile.linux": "zsh",
@@ -46,7 +51,7 @@
     // Use 'postCreateCommand' to run commands after the container is created.
     // We're using a gist, but you can also reference the raw install-tool from your repo.
     // Unless you mount the scripts folder as
-    "postCreateCommand": "echo Welcome to Cyfrin's dev-container. If you'd like to build your own, you can check out an article The Red Guild have created for you at their blog under https://blog.theredguild.org/where-do-you-run-your-code;zsh"
+    "postCreateCommand": "echo Welcome to Cyfrin's dev-container. If you'd like to build your own, you can check out an article The Red Guild have created for you at their blog under https://blog.theredguild.org/where-do-you-run-your-code"
     // Uncomment to connect as root instead. More info: https://aka.ms/dev-containers-non-root.
     // "remoteUser": "root"
 }

--- a/foundry/unmounted/.devcontainer/devcontainer.json
+++ b/foundry/unmounted/.devcontainer/devcontainer.json
@@ -21,7 +21,7 @@
                 "NomicFoundation.hardhat-solidity",
                 "tintinweb.solidity-visual-auditor",
                 "trailofbits.weaudit",
-                "tintinweb.solidity-metrics",
+                "tintinweb.solidity-metrics"
             ],
             "settings": {
                 "terminal.integrated.defaultProfile.linux": "zsh",

--- a/foundry/unmounted/.devcontainer/devcontainer.json
+++ b/foundry/unmounted/.devcontainer/devcontainer.json
@@ -22,11 +22,6 @@
                 "tintinweb.solidity-visual-auditor",
                 "trailofbits.weaudit",
                 "tintinweb.solidity-metrics",
-                "eamodio.gitlens",
-                "mhutchie.git-graph",
-                "GitHub.copilot",
-                "GitHub.copilot-chat",
-                "tamasfe.even-better-toml"
             ],
             "settings": {
                 "terminal.integrated.defaultProfile.linux": "zsh",

--- a/moccasin/mounted/.devcontainer/devcontainer.json
+++ b/moccasin/mounted/.devcontainer/devcontainer.json
@@ -43,7 +43,7 @@
     // Use 'postCreateCommand' to run commands after the container is created.
     // We're using a gist, but you can also reference the raw install-tool from your repo.
     // Unless you mount the scripts folder as
-    "postCreateCommand": "echo Welcome to Cyfrin's dev-container. If you'd like to build your own, you can check out an article The Red Guild have created for you at their blog under https://blog.theredguild.org/where-do-you-run-your-code;zsh"
+    "postCreateCommand": "echo Welcome to Cyfrin's dev-container. If you'd like to build your own, you can check out an article The Red Guild have created for you at their blog under https://blog.theredguild.org/where-do-you-run-your-code"
     // Uncomment to connect as root instead. More info: https://aka.ms/dev-containers-non-root.
     // "remoteUser": "root"
 }

--- a/moccasin/unmounted/.devcontainer/devcontainer.json
+++ b/moccasin/unmounted/.devcontainer/devcontainer.json
@@ -45,7 +45,7 @@
     // Use 'postCreateCommand' to run commands after the container is created.
     // We're using a gist, but you can also reference the raw install-tool from your repo.
     // Unless you mount the scripts folder as
-    "postCreateCommand": "echo Welcome to Cyfrin's dev-container. If you'd like to build your own, you can check out an article The Red Guild have created for you at their blog under https://blog.theredguild.org/where-do-you-run-your-code;zsh"
+    "postCreateCommand": "echo Welcome to Cyfrin's dev-container. If you'd like to build your own, you can check out an article The Red Guild have created for you at their blog under https://blog.theredguild.org/where-do-you-run-your-code"
     // Uncomment to connect as root instead. More info: https://aka.ms/dev-containers-non-root.
     // "remoteUser": "root"
 }


### PR DESCRIPTION
Fixed a syntax error in devcontainer.json by removing the unexpected `;zsh` at the end of the welcome message, which created an invalid link for `https://blog.theredguild.org/where-do-you-run-your-code` in the terminal prompt when the container was built.